### PR TITLE
New csv + serde parsing, with cleaner type inference; new `TsvRecordI…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ bytes = "1.5.0"
 ndarray-npy = { version = "0.8.1", optional = true }
 num-traits = "0.2.18"
 lazy_static = "1.4.0"
-medians = "3.0.6"
+csv = "1.3.0"
+serde = { version = "1.0.197", features = ["derive"] }
 
 [features]
 # cli = [ "clap" ]  # TODO make feature
@@ -52,5 +53,9 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 
 [[bench]]
 name = "bedtools_comparison"
+harness = false
+
+[[bench]]
+name = "io"
 harness = false
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ let results_gr = left_gr
     // Find overlaps
     .left_overlaps(&right_gr)?
     // Summarize overlap data
-    .map_over_joins(mean_score)?;
+    .map_joins(mean_score)?;
 ```
 
 where `mean_score()` is:

--- a/benches/io.rs
+++ b/benches/io.rs
@@ -1,0 +1,66 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use csv::{self, ReaderBuilder};
+use granges::io::parsers::Bed5Addition;
+use granges::ranges::GenomicRangeRecord;
+use granges::test_utilities::random_bed5file;
+use granges::{prelude::*, Position};
+
+#[derive(Debug, serde::Deserialize, PartialEq)]
+struct Bed5Row {
+    seqname: String,
+    start: Position,
+    end: Position,
+    name: String,
+    score: f64,
+}
+
+const BED_LENGTH: usize = 1_000_000;
+
+fn bench_io_shootout(c: &mut Criterion) {
+    // create the benchmark group
+    let mut group = c.benchmark_group("adjust");
+
+    // create the test data
+    let input_bedfile = random_bed5file(BED_LENGTH);
+
+    let genome = read_seqlens("tests_data/hg38_seqlens.tsv").unwrap();
+
+    // configure the sample size for the group
+    group.sample_size(10);
+
+    // Bed5Iterator
+    group.bench_function("bed5iterator", |b| {
+        b.iter(|| {
+            let iter = Bed5Iterator::new(input_bedfile.path()).unwrap();
+            let gr = GRanges::from_iter(iter, &genome).unwrap();
+            gr.len()
+        });
+    });
+
+    // CSV
+    group.bench_function("csv", |b| {
+        b.iter(|| {
+            let mut rdr = ReaderBuilder::new()
+                .delimiter(b'\t')
+                .has_headers(false)
+                .from_path(input_bedfile.path())
+                .unwrap();
+
+            let iter = rdr.deserialize();
+            let mut gr: GRanges<VecRangesIndexed, Vec<Bed5Addition>> = GRanges::new_vec(&genome);
+
+            for result in iter {
+                let row: GenomicRangeRecord<Bed5Addition> = result.unwrap();
+                let data = Bed5Addition {
+                    name: row.data.name,
+                    score: row.data.score,
+                };
+                gr.push_range(&row.seqname, row.start, row.end, data)
+                    .unwrap();
+            }
+        });
+    });
+}
+
+criterion_group!(benches, bench_io_shootout,);
+criterion_main!(benches);

--- a/examples/mean_score.rs
+++ b/examples/mean_score.rs
@@ -1,17 +1,19 @@
-use granges::{prelude::*, join::CombinedJoinDataLeftEmpty};
+use granges::{join::CombinedJoinDataLeftEmpty, prelude::*};
 
 // Our overlap data processing function.
 pub fn mean_score(join_data: CombinedJoinDataLeftEmpty<Option<f64>>) -> f64 {
     // Get the "right data" -- the BED5 scores.
-    let overlap_scores: Vec<f64> = join_data.right_data.into_iter()
+    let overlap_scores: Vec<f64> = join_data
+        .right_data
+        .into_iter()
         // filter out missing values ('.' in BED)
-        .filter_map(|x| x).collect();
+        .filter_map(|x| x)
+        .collect();
 
     // calculate the mean
     let score_sum: f64 = overlap_scores.iter().sum();
     score_sum / (overlap_scores.len() as f64)
 }
-
 
 fn try_main() -> Result<(), granges::error::GRangesError> {
     // Mock sequence lengths (e.g. "genome" file)
@@ -30,18 +32,17 @@ fn try_main() -> Result<(), granges::error::GRangesError> {
         // Convert to interval trees.
         .into_coitrees()?
         // Extract out just the score from the additional BED5 columns.
-        .map_data(|bed5_cols| {
-            bed5_cols.score
-        })?;
+        .map_data(|bed5_cols| bed5_cols.score)?;
 
     // Compute overlaps and combine scores into mean.
     let results_gr = left_gr
         .left_overlaps(&right_gr)?
-        .map_over_joins(mean_score)?;
+        .map_joins(mean_score)?;
 
     results_gr.to_tsv(None::<String>, &BED_TSV)?;
     Ok(())
 }
 
-fn main() { try_main().unwrap(); }
-
+fn main() {
+    try_main().unwrap();
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -453,7 +453,7 @@ pub fn granges_map(
     let left_join_gr = left_gr.left_overlaps(&right_gr)?;
 
     // Process all the overlaps.
-    let result_gr = left_join_gr.map_over_joins(|join_data| {
+    let result_gr = left_join_gr.map_joins(|join_data| {
         // Get the "right data" -- the BED5 scores
         let mut overlap_scores: Vec<f64> = join_data
             .right_data

--- a/src/data/operations.rs
+++ b/src/data/operations.rs
@@ -20,8 +20,8 @@ pub fn median<F: Float + Sum>(numbers: &mut [F]) -> Option<F> {
     }
     let mid = numbers.len() / 2;
     if numbers.len() % 2 == 0 {
-        numbers.select_nth_unstable_by(mid-1, |a, b| a.partial_cmp(b).unwrap());
-        let lower = numbers[mid-1];
+        numbers.select_nth_unstable_by(mid - 1, |a, b| a.partial_cmp(b).unwrap());
+        let lower = numbers[mid - 1];
         numbers.select_nth_unstable_by(mid, |a, b| a.partial_cmp(b).unwrap());
         let upper = numbers[mid];
         Some((lower + upper) / F::from(2.0).unwrap())
@@ -93,7 +93,7 @@ impl Operation {
 
 #[cfg(test)]
 mod tests {
-        use super::*;
+    use super::*;
 
     #[test]
     fn test_median_empty() {
@@ -118,5 +118,4 @@ mod tests {
         let mut numbers = vec![-3.0, -1.0, -2.0];
         assert_eq!(median(&mut numbers), Some(-2.0));
     }
-
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,9 @@ pub enum GRangesError {
     #[error("File reading error: {0}. Please check if the file exists and you have permission to read it.")]
     IOError(#[from] std::io::Error),
 
+    #[error("File parsing error: {0}")]
+    TsvParsingError(#[from] csv::Error),
+
     // File parsing related errors
     #[error("Could not determine the file type based on its extension. Ensure the file has a standard genomic data extension (.bed, .gff, etc.).")]
     CouldNotDetectRangesFiletype,

--- a/src/granges.rs
+++ b/src/granges.rs
@@ -806,7 +806,7 @@ where
     /// See [`CombinedJoinData`] and its convenience methods, which are designed
     /// to help downstream statistical calculations that could use the number of overlapping
     /// basepairs, overlapping fraction, etc.
-    pub fn map_over_joins<F, V>(
+    pub fn map_joins<F, V>(
         mut self,
         func: F,
     ) -> Result<GRanges<VecRangesIndexed, Vec<V>>, GRangesError>
@@ -847,7 +847,7 @@ impl GRanges<VecRangesIndexed, JoinDataBothEmpty> {
     /// to help downstream statistical calculations that could use the number of overlapping
     /// basepairs, overlapping fraction, etc.
 
-    pub fn map_over_joins<F, V>(
+    pub fn map_joins<F, V>(
         mut self,
         func: F,
     ) -> Result<GRanges<VecRangesIndexed, Vec<V>>, GRangesError>
@@ -885,7 +885,7 @@ where
     /// See [`CombinedJoinDataRightEmpty`] and its convenience methods, which are designed
     /// to help downstream statistical calculations that could use the number of overlapping
     /// basepairs, overlapping fraction, etc.
-    pub fn map_over_joins<F, V>(
+    pub fn map_joins<F, V>(
         mut self,
         func: F,
     ) -> Result<GRanges<VecRangesIndexed, Vec<V>>, GRangesError>
@@ -924,7 +924,7 @@ where
     /// to help downstream statistical calculations that could use the number of overlapping
     /// basepairs, overlapping fraction, etc.
 
-    pub fn map_over_joins<F, V>(
+    pub fn map_joins<F, V>(
         mut self,
         func: F,
     ) -> Result<GRanges<VecRangesIndexed, Vec<V>>, GRangesError>
@@ -1470,7 +1470,7 @@ mod tests {
     }
 
     #[test]
-    fn test_map_over_joins() {
+    fn test_map_oins() {
         let sl = seqlens!("chr1" => 50);
         let windows: GRangesEmpty<VecRangesEmpty> =
             GRangesEmpty::from_windows(&sl, 10, None, true).unwrap();
@@ -1487,7 +1487,7 @@ mod tests {
         let joined_results = windows
             .left_overlaps(&right_gr)
             .unwrap()
-            .map_over_joins(|join_data| {
+            .map_joins(|join_data| {
                 let overlap_scores = join_data.right_data;
                 overlap_scores.iter().sum::<f64>()
             })

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,7 +6,7 @@ pub mod tsv;
 
 pub use file::{InputStream, OutputStream};
 pub use parsers::{
-    Bed3Iterator, Bed5Iterator, BedlikeIterator, GenomicRangesFile, GenomicRangesParser,
-    TsvRecordIterator,
+    bed::Bed3Iterator, bed::Bed5Iterator, bed::BedlikeIterator, tsv::TsvRecordIterator,
+    GenomicRangesFile, GenomicRangesParser,
 };
 pub use tsv::BED_TSV;

--- a/src/io/parsers/bed.rs
+++ b/src/io/parsers/bed.rs
@@ -1,0 +1,306 @@
+//! BED Types and Functionality
+//!
+//! The BED (Browser Extensible Format) is a TSV format in bioinformatics.
+//! It has a fairly strict [specification](https://samtools.github.io/hts-specs/BEDv1.pdf),
+//! but in practice it is quite permissive, and in bioinformatics one encounters lots
+//! of "BED-like" files.
+//!
+//! # Design
+//!
+//! Since BED files can be thought of BED3 + an optional *addition*, the type
+//! returned by these parsing iterators is [`GenomicRangeRecord<U>`] where
+//! `U` is some sort of addition type like [`Bed5Addition`].
+//!
+//! # ⚠️ Stability
+//!
+//! This module defines core BED types, but is under active development.
+//!
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer};
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use crate::error::GRangesError;
+use crate::io::tsv::TsvConfig;
+use crate::io::InputStream;
+use crate::ranges::{GenomicRangeEmptyRecord, GenomicRangeRecord};
+use crate::traits::TsvSerialize;
+use crate::Position;
+
+use super::parse_column;
+use super::tsv::TsvRecordIterator;
+
+/// [`serde`] deserializer for a BED column with a possibly missing value. Note that the [BED
+/// specification](https://samtools.github.io/hts-specs/BEDv1.pdf) only technically allows `'.'` to
+/// be used for missing strands, but in practice it can be found to represent
+/// missing scores, etc too.
+pub fn deserialize_bed_missing<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + FromStr,
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    let missing_chars = &["."];
+    deserialize_option_generic(deserializer, missing_chars) // Use the generic deserializer with specific placeholders
+}
+
+/// The additional two BED5 columns.
+///
+/// # Fields
+/// * `name`: the feature name.
+/// * `score`: a score.
+// TODO/RENAME: maybe since this goes against spec it should
+// be called Bed5AdditionPermissive?
+#[derive(Clone, Debug, Deserialize)]
+pub struct Bed5Addition {
+    pub name: String,
+    #[serde(deserialize_with = "deserialize_bed_missing")]
+    pub score: Option<f64>,
+}
+
+/// An iterator over BED5 entries, which contain the three
+/// range entries (sequence name, start and end positions),
+/// a feature name, and a score.
+///
+/// Note that the [`Bed5Addition`] is *permissive* in the sense
+/// it allows for more input types than the official [BED format
+/// specification](https://samtools.github.io/hts-specs/BEDv1.pdf).
+// TODO strict type?
+#[derive(Debug)]
+pub struct Bed5Iterator {
+    iter: TsvRecordIterator<GenomicRangeRecord<Bed5Addition>>,
+}
+
+impl Bed5Iterator {
+    /// Creates a parsing iterator over a BED5 file.
+    pub fn new(filepath: impl Into<PathBuf>) -> Result<Self, GRangesError> {
+        let iter = TsvRecordIterator::new(filepath)?;
+
+        Ok(Self { iter })
+    }
+}
+
+impl Iterator for Bed5Iterator {
+    type Item = Result<GenomicRangeRecord<Bed5Addition>, GRangesError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+/// An iterator over BED3 entries (which just contain ranges no data).
+#[derive(Debug)]
+pub struct Bed3Iterator {
+    iter: TsvRecordIterator<GenomicRangeEmptyRecord>,
+}
+
+impl Bed3Iterator {
+    /// Creates a parsing iterator over a BED5 file.
+    pub fn new(filepath: impl Into<PathBuf>) -> Result<Self, GRangesError> {
+        let iter = TsvRecordIterator::new(filepath)?;
+        Ok(Self { iter })
+    }
+}
+
+impl Iterator for Bed3Iterator {
+    type Item = Result<GenomicRangeEmptyRecord, GRangesError>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+/// Nucleotide strand enum type.
+#[derive(Clone, Debug)]
+pub enum Strand {
+    Forward,
+    Reverse,
+}
+
+impl TsvSerialize for Option<Strand> {
+    #![allow(unused_variables)]
+    fn to_tsv(&self, config: &TsvConfig) -> String {
+        match self {
+            Some(Strand::Forward) => "+".to_string(),
+            Some(Strand::Reverse) => "-".to_string(),
+            None => config.no_value_string.to_string(),
+        }
+    }
+}
+
+/// Deserializes some value of type `t` with some possible missing
+/// character `missing_chars` into [`Option<T>`].
+pub fn deserialize_option_generic<'de, D, T>(
+    deserializer: D,
+    missing_chars: &'de [&'de str],
+) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + FromStr,
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    if missing_chars.contains(&s.as_str()) {
+        Ok(None)
+    } else {
+        s.parse::<T>()
+            .map(Some)
+            .map_err(|e| DeError::custom(format!("parsing error: {}", e)))
+    }
+}
+
+//impl Selection for &Bed5Addition {
+//    fn select_by_name(&self, name: &str) -> DatumType {
+//        match name {
+//            "name" => DatumType::String(self.name.clone()),
+//            "score" => DatumType::Float64(self.score),
+//            _ => panic!("No item named '{}'", name),
+//        }
+//    }
+//}
+
+impl TsvSerialize for &Bed5Addition {
+    #![allow(unused_variables)]
+    fn to_tsv(&self, config: &TsvConfig) -> String {
+        format!(
+            "{}\t{}",
+            self.name,
+            self.score
+                .as_ref()
+                .map_or(config.no_value_string.clone(), |x| x.to_string())
+        )
+    }
+}
+
+impl TsvSerialize for Bed5Addition {
+    #![allow(unused_variables)]
+    fn to_tsv(&self, config: &TsvConfig) -> String {
+        format!(
+            "{}\t{}",
+            self.name,
+            self.score
+                .as_ref()
+                .map_or(config.no_value_string.clone(), |x| x.to_string())
+        )
+    }
+}
+
+///// The additional three BED6 columns.
+//#[derive(Clone, Debug)]
+//pub struct Bed6Addition {
+//    pub name: String,
+//    pub score: f64,
+//    pub strand: Option<Strand>,
+//}
+
+/// A lazy parser for BED-like files.
+/// yields [`GenomicRangeRecord<Option<Vec<String>>>`] entries. If the file is a BED3 file,
+/// the data in the [`GenomicRangeRecord`] will be set to `None`, since there are no remaining
+/// string columns to parse.
+pub struct BedlikeIterator {
+    reader: BufReader<Box<dyn std::io::Read>>,
+}
+
+impl std::fmt::Debug for BedlikeIterator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BedlikeIterator").finish_non_exhaustive()
+    }
+}
+
+impl BedlikeIterator {
+    /// Create a new lazy-parsing iterator over Bed-like TSV data. This parser
+    /// assumes the first three columns are the sequence name, start (0-indexed and inclusive),
+    /// and end (0-indeed and exclusive) positions.
+    pub fn new(filepath: impl Into<PathBuf>) -> Result<Self, GRangesError> {
+        let mut input_file = InputStream::new(filepath);
+        let _has_metadata = input_file.collect_metadata("#", None);
+        let reader = input_file.continue_reading()?;
+        Ok(Self { reader })
+    }
+}
+
+impl Iterator for BedlikeIterator {
+    type Item = Result<GenomicRangeRecord<Option<String>>, GRangesError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut line = String::new();
+        match self.reader.read_line(&mut line) {
+            Ok(0) => None,
+            Ok(_) => {
+                let line = line.trim_end();
+                Some((parse_bed_lazy)(line))
+            }
+            Err(e) => Some(Err(GRangesError::IOError(e))),
+        }
+    }
+}
+
+/// Lazily parses a BED* format line into the first three columns defining the range,
+/// storing the rest as a `String`.
+///
+/// Unlike [`parse_bedlike()`], this function returns a concrete
+/// [`GenomicRangeRecord<Option<String>>`] type, not a [`Vec<String>`] of split TSV columns.
+pub fn parse_bed_lazy(line: &str) -> Result<GenomicRangeRecord<Option<String>>, GRangesError> {
+    let columns: Vec<&str> = line.splitn(4, '\t').collect();
+    if columns.len() < 3 {
+        return Err(GRangesError::Bed3TooFewColumns(
+            columns.len(),
+            line.to_string(),
+        ));
+    }
+
+    let seqname = parse_column(columns[0], line)?;
+    let start: Position = parse_column(columns[1], line)?;
+    let end: Position = parse_column(columns[2], line)?;
+
+    let data = if columns.len() > 3 {
+        Some(columns[3].to_string())
+    } else {
+        None
+    };
+
+    Ok(GenomicRangeRecord {
+        seqname,
+        start,
+        end,
+        data,
+    })
+}
+
+#[allow(dead_code)]
+fn parse_strand(symbol: char) -> Result<Option<Strand>, GRangesError> {
+    match symbol {
+        '+' => Ok(Some(Strand::Forward)),
+        '-' => Ok(Some(Strand::Reverse)),
+        '.' => Ok(None),
+        _ => Err(GRangesError::InvalidString),
+    }
+}
+
+// TODO
+///// Parses a BED6 format line into the three columns defining the range, and additional
+///// columns
+/////
+//pub fn parse_bed6(line: &str) -> Result<GenomicRangeRecord<Bed5Addition>, GRangesError> {
+//    let columns: Vec<&str> = line.splitn(4, '\t').collect();
+//    if columns.len() < 3 {
+//        return Err(GRangesError::BedlikeTooFewColumns(line.to_string()));
+//    }
+//
+//    let seqname = parse_column(columns[0], line)?;
+//    let start: Position = parse_column(columns[1], line)?;
+//    let end: Position = parse_column(columns[2], line)?;
+//
+//    let name = parse_column(columns[3], line)?;
+//    // let strand: Option<Strand> = parse_strand(parse_column(columns[3], line)?)?;
+//
+//    let data = Bed5Addition { name, score };
+//
+//    Ok(GenomicRangeRecord {
+//        seqname,
+//        start,
+//        end,
+//        data,
+//    })
+//}

--- a/src/io/parsers/tsv.rs
+++ b/src/io/parsers/tsv.rs
@@ -1,0 +1,95 @@
+//! Essential TSV parsing functionality, which wraps the blazingly-fast [`csv`] crate's
+//! deserialization method using [`serde`].
+
+use csv::{DeserializeRecordsIntoIter, ReaderBuilder};
+use flate2::read::GzDecoder;
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer};
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use crate::error::GRangesError;
+
+/// Deserializes some value of type `t` with some possible missing
+/// character `missing_chars` into [`Option<T>`].
+pub fn deserialize_option_generic<'de, D, T>(
+    deserializer: D,
+    missing_chars: &'de [&'de str],
+) -> Result<Option<T>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + FromStr,
+    <T as FromStr>::Err: std::fmt::Display,
+{
+    let s: String = Deserialize::deserialize(deserializer)?;
+    if missing_chars.contains(&s.as_str()) {
+        Ok(None)
+    } else {
+        s.parse::<T>()
+            .map(Some)
+            .map_err(|e| DeError::custom(format!("parsing error: {}", e)))
+    }
+}
+
+/// An extensible TSV parser, which uses a supplied parser function to
+/// convert a line into a [`GenomicRangeRecord<U>`], a range with generic associated
+/// data.
+pub struct TsvRecordIterator<T> {
+    inner: DeserializeRecordsIntoIter<Box<dyn std::io::Read>, T>,
+}
+
+impl<T> std::fmt::Debug for TsvRecordIterator<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TsvRecordIterator").finish_non_exhaustive()
+    }
+}
+
+/// Check if a file is a gzipped by looking for the magic numbers
+fn is_gzipped_file(file_path: impl Into<PathBuf>) -> io::Result<bool> {
+    let mut file = File::open(file_path.into())?;
+    let mut buffer = [0; 2];
+    file.read_exact(&mut buffer)?;
+
+    Ok(buffer == [0x1f, 0x8b])
+}
+
+impl<T> TsvRecordIterator<T>
+where
+    for<'de> T: Deserialize<'de>,
+{
+    pub fn new(filepath: impl Into<PathBuf>) -> Result<Self, GRangesError> {
+        let filepath = filepath.into();
+
+        let file = File::open(&filepath)?;
+        let is_gzipped = is_gzipped_file(&filepath)?;
+        let stream: Box<dyn Read> = if is_gzipped {
+            Box::new(GzDecoder::new(file))
+        } else {
+            Box::new(file)
+        };
+
+        let reader = ReaderBuilder::new()
+            .delimiter(b'\t')
+            .has_headers(false)
+            .from_reader(stream);
+
+        let inner = reader.into_deserialize();
+
+        Ok(Self { inner })
+    }
+}
+
+impl<T> Iterator for TsvRecordIterator<T>
+where
+    for<'de> T: Deserialize<'de>,
+{
+    type Item = Result<T, GRangesError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|res| res.map_err(|e| GRangesError::IOError(e.into())))
+    }
+}

--- a/src/io/parsers/utils.rs
+++ b/src/io/parsers/utils.rs
@@ -1,0 +1,33 @@
+use std::path::Path;
+
+/// Get the *base* extension to help infer filetype, which ignores compression-related
+/// extensions (`.gz` and `.bgz`).
+pub fn get_base_extension<P: AsRef<Path>>(filepath: P) -> Option<String> {
+    let path = filepath.as_ref();
+
+    // get the filename and split by '.'
+    let parts: Vec<&str> = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("")
+        .split('.')
+        .collect();
+
+    let ignore_extensions = ["gz", "bgz"];
+
+    let has_ignore_extension = parts
+        .last()
+        .map_or(false, |ext| ignore_extensions.contains(ext));
+
+    if parts.len() > 2 && has_ignore_extension {
+        // if it's .gz, we return the second to last token,
+        // e.g. path/foo.bed.gz would return bed
+        Some(parts[parts.len() - 2].to_string())
+    } else if parts.len() > 1 {
+        // there is no .gz - return the last token.
+        Some(parts[parts.len() - 1].to_string())
+    } else {
+        // no extension found
+        None
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,9 +117,9 @@
 //! After a left grouped join, each left range can have zero or more overlapping right ranges.
 //! A *map-combine* operation (optionally) maps a function over all right ranges' data and
 //! overlaps information, and then combines that into a single data entry per left range. These
-//! combined data entries make up a new [`GRanges<R, Vec<V>>`] data container, returned by [`GRanges::map_over_joins()`].
+//! combined data entries make up a new [`GRanges<R, Vec<V>>`] data container, returned by [`GRanges::map_joins()`].
 //!
-//! Note that like [`GRanges::left_overlaps()`], the [`GRanges::map_over_joins()`] is endomorphic
+//! Note that like [`GRanges::left_overlaps()`], the [`GRanges::map_joins()`] is endomorphic
 //! over its range container. This means it can be passed through without modification, which
 //! is computationally efficient. This results from a Map-Combine operation then can be overlap joined with
 //! other genomic ranges, filtered, have its data arbitrarily manipulated by [`GRanges::map_data()`], etc.
@@ -171,7 +171,7 @@
 //! let left_join_gr = left_gr.left_overlaps(&right_gr)?;
 //!
 //! // Process all the overlaps.
-//! let results_gr = left_join_gr.map_over_joins(|join_data| {
+//! let results_gr = left_join_gr.map_joins(|join_data| {
 //!     // Get the "right data" -- the BED5 scores.
 //!     let overlap_scores: Vec<f64> = join_data.right_data.into_iter()
 //!            // filter out missing values ('.' in BED)
@@ -261,7 +261,7 @@
 //! 2. *Range-modifying* functions: [`GRanges::into_coitrees()`], [`GRanges::adjust_ranges()`], [`GRanges::sort()`],
 //!        [`GRanges::flanking_ranges()`], [`GRanges::filter_overlaps()`].
 //!
-//! 3. *Data-modifying* functions: [`GRanges::left_overlaps()`], [`GRanges::map_over_joins()`], [`GRanges::map_data()`].
+//! 3. *Data-modifying* functions: [`GRanges::left_overlaps()`], [`GRanges::map_joins()`], [`GRanges::map_data()`].
 //!
 //! 4. *Range and Data modifying* functions: [`GRanges::push_range()`].
 //!
@@ -340,7 +340,7 @@
 //! [`ndarray::Array2`]: ndarray::Array2
 //! [`GRanges::left_overlaps()`]: crate::traits::LeftOverlaps::left_overlaps
 //! [`GRanges<R, Vec<V>>`]: crate::granges::GRanges
-//! [`GRanges::map_over_joins()`]: crate::granges::GRanges::map_over_joins
+//! [`GRanges::map_joins()`]: crate::granges::GRanges::map_joins
 //! [`GRanges::map_data()`]: crate::granges::GRanges::map_data
 //! [`GRanges::new_vec()`]: crate::granges::GRanges::new_vec
 //! [`GRanges::into_coitrees()`]: crate::granges::GRanges::into_coitrees

--- a/src/main/mod.rs
+++ b/src/main/mod.rs
@@ -218,7 +218,7 @@ enum Commands {
         sort: bool,
 
         /// add an additional score columns
-        #[arg(short, long)]
+        #[arg(short = 'c', long)]
         scores: bool,
     },
 }

--- a/src/ranges/mod.rs
+++ b/src/ranges/mod.rs
@@ -2,6 +2,7 @@
 //!
 //!
 
+use serde::Deserialize;
 use std::ops::Range;
 
 use crate::{
@@ -161,7 +162,7 @@ impl AdjustableGenericRange for RangeIndexed {
 ///
 /// This is used as a type for holding a range with associated data directly
 /// from a parser.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct GenomicRangeRecord<U> {
     pub seqname: String,
     pub start: Position,
@@ -289,7 +290,7 @@ impl<U: TsvSerialize> TsvSerialize for GenomicRangeRecord<U> {
 }
 
 /// Represents a genomic range entry without data, e.g. from a BED3 parser.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct GenomicRangeEmptyRecord {
     pub seqname: String,
     pub start: Position,

--- a/src/test_utilities.rs
+++ b/src/test_utilities.rs
@@ -8,7 +8,7 @@ use crate::{
     create_granges_with_seqlens,
     error::GRangesError,
     granges::GRangesEmpty,
-    io::parsers::Bed5Addition,
+    io::parsers::bed::Bed5Addition,
     prelude::{GRanges, VecRangesIndexed},
     ranges::{
         coitrees::COITrees,


### PR DESCRIPTION
…terator`.

 - Rename of `map_over_joins()` to `map_joins()`.
 - New IO benchmark of our (old) `Bed5Iterator` vs csv + serde.
 - Reorganized `io::parsers` into different modules.
 - `deserialize_bed_missing()` and `deserialize_option_generic()` for missing value to `None`.
 - All new `Bed3Iterator`, `Bed5Iterator`, and `BedlikeIterator`
 - New `TsvRecordIterator` built on csv + serde.