### PR TITLE
add mimalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ num-traits = "0.2.18"
 lazy_static = "1.4.0"
 csv = "1.3.0"
 serde = { version = "1.0.197", features = ["derive"] }
+mimalloc = "0.1.42"
 
 [features]
 dev-commands = [ ]

--- a/src/main/mod.rs
+++ b/src/main/mod.rs
@@ -3,13 +3,18 @@ use std::path::PathBuf;
 use clap::{Parser, Subcommand};
 use granges::{
     commands::{
-        granges_adjust, granges_filter, granges_flank, granges_map, granges_windows, FilterChroms,
-        FeatureDensity, Merge, ProcessingMode,
+        granges_adjust, granges_filter, granges_flank, granges_map, granges_windows,
+        FeatureDensity, FilterChroms, Merge, ProcessingMode,
     },
     data::operations::FloatOperation,
     prelude::GRangesError,
     Position, PositionOffset,
 };
+
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[cfg(feature = "dev-commands")]
 use granges::commands::granges_random_bed;


### PR DESCRIPTION
I created this branch to play around with potential optimizations.  However, right now this PR just contains one (very trivial) optimization.  It replaces the global allocator with Mimalloc.  This is a highly-optimized allocator that generally outperforms the system malloc. Given the propensity of Granges to perform many small allocations, such a change seems to help.  I'd be very interested in your measurements!